### PR TITLE
update base image to jenkins/jenkins:lts-jdk21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # we add just some additional binaries
 #
 ##########################################
-FROM jenkins/jenkins:lts-jdk17
+FROM jenkins/jenkins:lts-jdk21
 LABEL org.opencontainers.image.authors="Peter Stadler for the ViFE"
 LABEL org.opencontainers.image.source="https://github.com/Edirom/Jenkins"
 


### PR DESCRIPTION
The updated Docker image is currently deployed for testing, so once we're happy with the testing this can be merged.